### PR TITLE
Refactor analyze endpoint to use file IDs

### DIFF
--- a/src/app/analysis/page.tsx
+++ b/src/app/analysis/page.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from "react";
 interface AnalysisResult {
   success: boolean;
   analysis?: string;
+  timestamp?: string;
   error?: string;
 }
 

--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -1,44 +1,31 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { GoogleGenerativeAI } from "@google/generative-ai";
-import fs from 'fs';
-import mime from 'mime-types';
-import { writeFile } from 'fs/promises';
-import path from 'path';
-import { v4 as uuidv4 } from 'uuid';
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import { GoogleAIFileManager } from '@google/generative-ai/server';
 
 export async function POST(req: NextRequest) {
   try {
-    const formData = await req.formData();
-    const file = formData.get('file') as File;
-    
-    if (!file) {
-      return NextResponse.json({ error: 'No file provided' }, { status: 400 });
+    const { fileId } = await req.json();
+    if (!fileId || typeof fileId !== 'string') {
+      return NextResponse.json({ success: false, error: 'No fileId provided' }, { status: 400 });
     }
-    
-    // Save file temporarily
-    const bytes = await file.arrayBuffer();
-    const buffer = Buffer.from(bytes);
-    const tempFilePath = path.join('/tmp', `${uuidv4()}-${file.name}`);
-    await writeFile(tempFilePath, buffer);
-    
-    // Initialize Gemini API
+
     const apiKey = process.env.GEMINI_API_KEY;
     if (!apiKey) {
-      return NextResponse.json({ error: 'API key not configured' }, { status: 500 });
+      return NextResponse.json({ success: false, error: 'API key not configured' }, { status: 500 });
     }
-    
+
     const genAI = new GoogleGenerativeAI(apiKey);
-    
-    // Get file content as base64
-    const fileContent = fs.readFileSync(tempFilePath);
-    const base64Content = fileContent.toString('base64');
-    const mimeType = mime.lookup(file.name) || 'application/octet-stream';
-    
-    // Get model with system instruction
+    const fileManager = new GoogleAIFileManager(apiKey);
+
+    // Retrieve the previously uploaded file from Google
+    const retrieved = await fileManager.retrieveFile(fileId);
+    const mimeType = retrieved.mimeType || 'application/octet-stream';
+    const base64Content = Buffer.from(retrieved.data).toString('base64');
+
     const model = genAI.getGenerativeModel({
-      model: "gemini-2.5-pro-preview-03-25",
-      systemInstruction: `You are BloodInsight AI, an assistant specialized in analyzing and explaining blood test and lab reports. 
-Your task is to:
+      model: 'gemini-2.5-pro-preview-03-25',
+      systemInstruction: `You are BloodInsight AI, an assistant specialized in analyzing and explaining blood test and lab reports.
+Your task is:
 1. Extract key metrics and values from the provided lab report
 2. Identify which values are within normal range and which are outside normal range
 3. Provide a clear, simple explanation of what each metric means and its significance
@@ -52,39 +39,32 @@ Important notes:
 - Organize information in a structured, easy-to-read format
 - Focus on factual information and avoid speculative diagnoses`,
     });
-    
-    // Configure generation parameters
+
     const generationConfig = {
       temperature: 1,
       topP: 0.95,
       topK: 64,
       maxOutputTokens: 65536,
     };
-    
-    // Start chat session and get response
-    const chatSession = model.startChat({
-      generationConfig,
-      history: [],
-    });
-    
+
+    const chatSession = model.startChat({ generationConfig, history: [] });
+
     const result = await chatSession.sendMessage([
       {
         inlineData: {
-          mimeType: mimeType,
-          data: base64Content
-        }
-      }
+          mimeType,
+          data: base64Content,
+        },
+      },
     ]);
-    
-    // Clean up temp file
-    fs.unlinkSync(tempFilePath);
-    
-    return NextResponse.json({ 
+
+    return NextResponse.json({
+      success: true,
       analysis: result.response.text(),
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     });
   } catch (error) {
     console.error('Error processing file:', error);
-    return NextResponse.json({ error: 'Failed to process file' }, { status: 500 });
+    return NextResponse.json({ success: false, error: 'Failed to process file' }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
- update `/api/analyze` endpoint to accept JSON `{fileId}`
- use `GoogleAIFileManager` to fetch uploaded file
- return success state from API
- include timestamp in `AnalysisResult` interface

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f997ecdc4832d827d0f5a40315a13