### PR TITLE
Fix gemini service usage

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -16,13 +16,14 @@ Before deploying, ensure you have:
 The following environment variables need to be configured in your Vercel project:
 
 ```
-NEXT_PUBLIC_GEMINI_API_KEY=your_gemini_api_key
+GEMINI_API_KEY=your_gemini_api_key
 NEXTAUTH_URL=your_deployment_url (e.g., https://bloodinsight-ai.vercel.app)
 NEXTAUTH_SECRET=your_nextauth_secret (generate with `openssl rand -base64 32`)
 GOOGLE_CLIENT_ID=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_client_secret
 DATABASE_URL=your_postgres_connection_string
 ```
+`GEMINI_API_KEY` must remain server-side; never expose it to the browser.
 
 ## Deployment Steps
 
@@ -67,7 +68,7 @@ npx prisma migrate deploy
 
 1. Go to the Google AI Studio (https://makersuite.google.com/)
 2. Get an API key for the Gemini API
-3. Set this as the `NEXT_PUBLIC_GEMINI_API_KEY` environment variable
+3. Set this as the `GEMINI_API_KEY` environment variable (server-side only)
 
 ### 5. Vercel Deployment
 

--- a/README.md
+++ b/README.md
@@ -54,13 +54,14 @@ BloodInsight AI is an AI-powered health analytics web application that helps peo
    ```
 3. Set up environment variables in a `.env` file:
    ```
-   NEXT_PUBLIC_GEMINI_API_KEY=your_gemini_api_key
+   GEMINI_API_KEY=your_gemini_api_key
    NEXTAUTH_URL=http://localhost:3000
    NEXTAUTH_SECRET=your_nextauth_secret
    GOOGLE_CLIENT_ID=your_google_client_id
    GOOGLE_CLIENT_SECRET=your_google_client_secret
    DATABASE_URL=your_postgres_connection_string
    ```
+   **Important:** keep `GEMINI_API_KEY` on the server only; it should never be exposed to the client.
 4. Initialize the database:
    ```bash
    npx prisma migrate dev

--- a/src/app/api/admin/gemini/route.ts
+++ b/src/app/api/admin/gemini/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getGeminiService } from '@/lib/gemini-service';
+
+export async function GET() {
+  const geminiService = getGeminiService();
+  return NextResponse.json({ systemPrompt: geminiService.getSystemPrompt() });
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const { action, value } = await req.json();
+    const geminiService = getGeminiService();
+
+    if (action === 'updateApiKey') {
+      geminiService.updateApiKey(value);
+      return NextResponse.json({ success: true });
+    } else if (action === 'updateSystemPrompt') {
+      geminiService.updateSystemPrompt(value);
+      return NextResponse.json({ success: true });
+    }
+
+    return NextResponse.json({ success: false, error: 'Invalid action' }, { status: 400 });
+  } catch (error) {
+    console.error('Admin gemini route error:', error);
+    return NextResponse.json({ success: false, error: 'Server error' }, { status: 500 });
+  }
+}

--- a/src/lib/gemini-service.ts
+++ b/src/lib/gemini-service.ts
@@ -1,4 +1,3 @@
-"use client";
 
 import { GoogleGenerativeAI } from "@google/generative-ai";
 


### PR DESCRIPTION
## Summary
- remove `"use client"` from gemini service so it only runs server-side
- route admin gemini API requests through `/api/admin/gemini`
- call that API from the admin page instead of importing the service directly
- document that the Gemini API key stays server-side

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9b1df34c832dbe51514b5525151c