### PR TITLE
Add admin session check to Gemini API

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -5,7 +5,7 @@ import type { User } from "next-auth";
 import type { JWT } from "next-auth/jwt"; // Keep type imports if needed elsewhere, adjust if not
 
 // Define authOptions with NextAuthOptions type for v4
-const authOptions: NextAuthOptions = {
+export const authOptions: NextAuthOptions = {
   providers: [
     GoogleProvider({
       // Ensure environment variables are defined and non-empty

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,10 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = global as unknown as { prisma: PrismaClient | undefined };
+
+export const prisma =
+  globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
+
+export default prisma;


### PR DESCRIPTION
## Summary
- export `authOptions` so server routes can authenticate
- add Prisma client helper
- verify session and admin status in `admin/gemini` route

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_683f9ce1cadc832d9fb61762290f0be6