### PR TITLE
Add admin gemini API docs

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -88,7 +88,9 @@ After deployment, you should:
 
 2. Access the admin console at `https://your-domain.vercel.app/admin`
 
-3. Update the Gemini API key and system prompt in the admin console
+3. Update the Gemini API key and system prompt in the admin console. These
+   updates are sent to the protected `/api/admin/gemini` endpoint using a JSON
+   payload with an `action` (`updateApiKey` or `updateSystemPrompt`) and `value`.
 
 ## Monitoring and Maintenance
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,22 @@ See [DEPLOYMENT.md](DEPLOYMENT.md) for detailed deployment instructions.
 - **Trends Analysis**: Interactive visualizations of health metrics over time
 - **Export Functionality**: PDF and CSV export options
 
+## Admin API
+
+The `/api/admin/gemini` endpoint allows administrators to manage Gemini-related
+settings. The route is protected by NextAuth and only users with `isAdmin = true`
+can access it. Unauthorized requests return `401` or `403`.
+
+- **GET** `/api/admin/gemini`
+  - Returns the current system prompt:
+    ```json
+    { "systemPrompt": "..." }
+    ```
+- **POST** `/api/admin/gemini`
+  - Accepts a JSON payload with `action` and `value` fields.
+    - `{"action": "updateApiKey", "value": "NEW_KEY"}` updates the Gemini API key.
+    - `{"action": "updateSystemPrompt", "value": "PROMPT_TEXT"}` updates the system prompt.
+
 ## Educational Purpose
 
 This application is for educational purposes only and is not intended to replace medical advice. Always consult with healthcare providers regarding lab results and health decisions.


### PR DESCRIPTION
## Summary
- document `/api/admin/gemini` usage and authentication requirements
- mention the admin API in deployment instructions

## Testing
- `npm install` *(fails: could not resolve dependency)*

------
https://chatgpt.com/codex/tasks/task_e_683f9f621aa0832da60ea868f38bc19a