### PR TITLE
Persist Gemini settings in database

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ can access it. Unauthorized requests return `401` or `403`.
     { "systemPrompt": "..." }
     ```
 - **POST** `/api/admin/gemini`
-  - Accepts a JSON payload with `action` and `value` fields.
-    - `{"action": "updateApiKey", "value": "NEW_KEY"}` updates the Gemini API key.
-    - `{"action": "updateSystemPrompt", "value": "PROMPT_TEXT"}` updates the system prompt.
+  - Accepts a JSON payload with `action` and `value` fields. The values are persisted in the database.
+    - `{"action": "updateApiKey", "value": "NEW_KEY"}` stores a new Gemini API key.
+    - `{"action": "updateSystemPrompt", "value": "PROMPT_TEXT"}` updates the default system prompt.
 
 ## Educational Purpose
 

--- a/prisma/migrations/0002_add_gemini_config.sql
+++ b/prisma/migrations/0002_add_gemini_config.sql
@@ -1,0 +1,8 @@
+-- Add GeminiConfig table for storing Gemini API key
+CREATE TABLE "GeminiConfig" (
+    "id" TEXT NOT NULL,
+    "apiKey" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "GeminiConfig_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -119,3 +119,10 @@ model ApiUsage {
   createdAt   DateTime @default(now())
   userId      String?
 }
+
+model GeminiConfig {
+  id        String   @id @default(cuid())
+  apiKey    String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}

--- a/src/app/api/admin/gemini/route.ts
+++ b/src/app/api/admin/gemini/route.ts
@@ -21,7 +21,7 @@ async function verifyAdmin() {
 export async function GET(req: NextRequest) {
   const errorResponse = await verifyAdmin();
   if (errorResponse) return errorResponse;
-  const geminiService = getGeminiService();
+  const geminiService = await getGeminiService();
   return NextResponse.json({ systemPrompt: geminiService.getSystemPrompt() });
 }
 
@@ -30,13 +30,13 @@ export async function POST(req: NextRequest) {
     const errorResponse = await verifyAdmin();
     if (errorResponse) return errorResponse;
     const { action, value } = await req.json();
-    const geminiService = getGeminiService();
+    const geminiService = await getGeminiService();
 
     if (action === 'updateApiKey') {
-      geminiService.updateApiKey(value);
+      await geminiService.updateApiKey(value);
       return NextResponse.json({ success: true });
     } else if (action === 'updateSystemPrompt') {
-      geminiService.updateSystemPrompt(value);
+      await geminiService.updateSystemPrompt(value);
       return NextResponse.json({ success: true });
     }
 


### PR DESCRIPTION
## Summary
- add `GeminiConfig` model and migration
- load API key and system prompt from database
- make `getGeminiService` asynchronous
- update admin API route to persist updates
- document new behaviour in README

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_683fa01fef98832dbe2901ba6ade44d4