### PR TITLE
Add global not-found page

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import Link from 'next/link'
+
+export default function NotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen gap-4 text-center">
+      <h2 className="text-3xl font-bold">Page Not Found</h2>
+      <p className="text-muted-foreground">Sorry, we couldn\'t find the page you were looking for.</p>
+      <Link href="/dashboard" className="text-primary underline">
+        Go back to Dashboard
+      </Link>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `src/app/not-found.tsx` to show a friendly 404 page with a dashboard link

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fa473e9e4832d80d96b7bb311e1cb