### PR TITLE
Implement usage metrics dashboard

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -12,13 +12,29 @@ export default function AdminPage() {
   const [systemPrompt, setSystemPrompt] = useState("");
   const [isUpdating, setIsUpdating] = useState(false);
   const [updateMessage, setUpdateMessage] = useState({ type: "", message: "" });
+  const [usageStats, setUsageStats] = useState({
+    totalUsers: 0,
+    activeUsers: 0,
+    totalReports: 0,
+    reportsToday: 0,
+    apiCalls: 0,
+    averageProcessingTime: 0,
+  });
+  const [userActivity, setUserActivity] = useState<{
+    time: string;
+    user: string;
+    action: string;
+    duration: number;
+  }[]>([]);
 
-  // Load the current system prompt from the server when the component mounts
+  // Load the current system prompt and usage stats from the server when the component mounts
   useEffect(() => {
     fetch("/api/admin/gemini")
       .then((res) => res.json())
       .then((data) => {
         if (data.systemPrompt) setSystemPrompt(data.systemPrompt);
+        if (data.usageStats) setUsageStats(data.usageStats);
+        if (data.userActivity) setUserActivity(data.userActivity);
       })
       .catch((err) => console.error(err));
   }, []);
@@ -76,24 +92,6 @@ export default function AdminPage() {
     }
   };
 
-  // Sample data for the dashboard
-  const usageStats = {
-    totalUsers: 127,
-    activeUsers: 42,
-    totalReports: 315,
-    reportsToday: 18,
-    apiCalls: 289,
-    averageProcessingTime: "2.3s",
-  };
-
-  // Sample data for user activity
-  const userActivity = [
-    { time: "2025-04-02 21:45", user: "user123@example.com", action: "Uploaded lab report", reportType: "Blood Panel" },
-    { time: "2025-04-02 21:30", user: "user456@example.com", action: "Viewed trends", reportType: "N/A" },
-    { time: "2025-04-02 21:15", user: "user789@example.com", action: "Uploaded lab report", reportType: "Lipid Panel" },
-    { time: "2025-04-02 21:00", user: "user123@example.com", action: "Exported results", reportType: "N/A" },
-    { time: "2025-04-02 20:45", user: "user321@example.com", action: "Uploaded lab report", reportType: "Comprehensive Metabolic Panel" },
-  ];
 
   return (
     <AdminRoute>
@@ -168,7 +166,7 @@ export default function AdminPage() {
                       <p className="text-sm text-muted-foreground">API Calls</p>
                     </div>
                     <div>
-                      <p className="text-3xl font-bold">{usageStats.averageProcessingTime}</p>
+                      <p className="text-3xl font-bold">{usageStats.averageProcessingTime}ms</p>
                       <p className="text-sm text-muted-foreground">Avg. Processing</p>
                     </div>
                   </div>
@@ -184,7 +182,7 @@ export default function AdminPage() {
                         <th className="text-left py-3 px-4 text-sm font-medium text-muted-foreground">Time</th>
                         <th className="text-left py-3 px-4 text-sm font-medium text-muted-foreground">User</th>
                         <th className="text-left py-3 px-4 text-sm font-medium text-muted-foreground">Action</th>
-                        <th className="text-left py-3 px-4 text-sm font-medium text-muted-foreground">Report Type</th>
+                        <th className="text-left py-3 px-4 text-sm font-medium text-muted-foreground">Duration (ms)</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -193,7 +191,7 @@ export default function AdminPage() {
                           <td className="py-3 px-4 text-sm">{activity.time}</td>
                           <td className="py-3 px-4 text-sm">{activity.user}</td>
                           <td className="py-3 px-4 text-sm">{activity.action}</td>
-                          <td className="py-3 px-4 text-sm">{activity.reportType}</td>
+                          <td className="py-3 px-4 text-sm">{activity.duration}</td>
                         </tr>
                       ))}
                     </tbody>

--- a/src/app/api/admin/gemini/route.ts
+++ b/src/app/api/admin/gemini/route.ts
@@ -4,45 +4,125 @@ import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 import { prisma } from '@/lib/prisma';
 import { getGeminiService } from '@/lib/gemini-service';
 
-async function verifyAdmin() {
+type VerifyResult = { user: { id: string } } | { error: NextResponse };
+
+async function verifyAdmin(): Promise<VerifyResult> {
   const session = await getServerSession(authOptions);
   if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    return { error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) };
   }
   const user = await prisma.user.findUnique({
     where: { email: session.user?.email ?? '' },
+    select: { id: true, isAdmin: true },
   });
   if (!user?.isAdmin) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    return { error: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) };
   }
-  return null;
+  return { user: { id: user.id } };
 }
 
 export async function GET(req: NextRequest) {
-  const errorResponse = await verifyAdmin();
-  if (errorResponse) return errorResponse;
+  const start = Date.now();
+  const result = await verifyAdmin();
+  if ('error' in result) return result.error;
   const geminiService = await getGeminiService();
-  return NextResponse.json({ systemPrompt: geminiService.getSystemPrompt() });
+
+  const systemPrompt = geminiService.getSystemPrompt();
+
+  // Gather usage statistics
+  const totalUsers = await prisma.user.count();
+  const activeUsers = await prisma.session.count({
+    where: { expires: { gt: new Date() } },
+    distinct: ['userId'],
+  });
+  const totalReports = await prisma.report.count();
+  const startOfToday = new Date();
+  startOfToday.setHours(0, 0, 0, 0);
+  const reportsToday = await prisma.report.count({ where: { createdAt: { gte: startOfToday } } });
+  const apiAggregates = await prisma.apiUsage.aggregate({
+    _count: true,
+    _avg: { duration: true },
+  });
+
+  const recent = await prisma.apiUsage.findMany({
+    orderBy: { createdAt: 'desc' },
+    take: 5,
+  });
+
+  const userIds = recent.map(r => r.userId).filter(Boolean) as string[];
+  const users = await prisma.user.findMany({ where: { id: { in: userIds } }, select: { id: true, email: true } });
+  const userMap = Object.fromEntries(users.map(u => [u.id, u.email]));
+
+  const userActivity = recent.map(r => ({
+    time: r.createdAt.toISOString(),
+    user: r.userId ? userMap[r.userId] || 'Unknown' : 'Anonymous',
+    action: `${r.endpoint} (${r.status})`,
+    duration: r.duration,
+  }));
+
+  await prisma.apiUsage.create({
+    data: {
+      endpoint: '/api/admin/gemini',
+      duration: Date.now() - start,
+      status: 'success',
+      userId: result.user.id,
+    },
+  });
+
+  return NextResponse.json({
+    systemPrompt,
+    usageStats: {
+      totalUsers,
+      activeUsers,
+      totalReports,
+      reportsToday,
+      apiCalls: apiAggregates._count,
+      averageProcessingTime: Math.round(apiAggregates._avg.duration ?? 0),
+    },
+    userActivity,
+  });
 }
 
 export async function POST(req: NextRequest) {
+  const start = Date.now();
   try {
-    const errorResponse = await verifyAdmin();
-    if (errorResponse) return errorResponse;
+    const result = await verifyAdmin();
+    if ('error' in result) return result.error;
     const { action, value } = await req.json();
     const geminiService = await getGeminiService();
 
+    let success = false;
+
     if (action === 'updateApiKey') {
       await geminiService.updateApiKey(value);
-      return NextResponse.json({ success: true });
+      success = true;
     } else if (action === 'updateSystemPrompt') {
       await geminiService.updateSystemPrompt(value);
-      return NextResponse.json({ success: true });
+      success = true;
+    } else {
+      return NextResponse.json({ success: false, error: 'Invalid action' }, { status: 400 });
     }
 
-    return NextResponse.json({ success: false, error: 'Invalid action' }, { status: 400 });
+    await prisma.apiUsage.create({
+      data: {
+        endpoint: '/api/admin/gemini',
+        duration: Date.now() - start,
+        status: 'success',
+        userId: result.user.id,
+      },
+    });
+
+    return NextResponse.json({ success });
   } catch (error) {
     console.error('Admin gemini route error:', error);
+    await prisma.apiUsage.create({
+      data: {
+        endpoint: '/api/admin/gemini',
+        duration: Date.now() - start,
+        status: 'error',
+        errorMessage: error instanceof Error ? error.message : 'Unknown error',
+      },
+    });
     return NextResponse.json({ success: false, error: 'Server error' }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
- log API requests to `ApiUsage` table
- expose Gemini settings and metrics via `/api/admin/gemini`
- display real stats on admin dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fa57fdff0832d91498483aa43a041