### PR TITLE
Add API route tests

### DIFF
--- a/tests/admin-gemini.test.ts
+++ b/tests/admin-gemini.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+let getServerSessionMock: any;
+let findUniqueMock: any;
+let geminiServiceMock: any;
+
+vi.mock('next-auth/next', () => ({
+  getServerSession: (...args: any[]) => getServerSessionMock(...args)
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: { findUnique: (...args: any[]) => findUniqueMock(...args) }
+  }
+}));
+
+vi.mock('@/lib/gemini-service', () => ({
+  getGeminiService: () => geminiServiceMock
+}));
+
+describe('admin gemini route auth', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    getServerSessionMock = vi.fn();
+    findUniqueMock = vi.fn();
+    geminiServiceMock = { getSystemPrompt: vi.fn().mockReturnValue('prompt') };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns 401 if not authenticated', async () => {
+    getServerSessionMock.mockResolvedValue(null);
+    const { GET } = await import('../src/app/api/admin/gemini/route');
+    const res = await GET(new Request('http://test') as any);
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('returns 403 if user not admin', async () => {
+    getServerSessionMock.mockResolvedValue({ user: { email: 'a@test.com' } });
+    findUniqueMock.mockResolvedValue({ isAdmin: false });
+    const { GET } = await import('../src/app/api/admin/gemini/route');
+    const res = await GET(new Request('http://test') as any);
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'Forbidden' });
+  });
+
+  it('allows access when admin', async () => {
+    getServerSessionMock.mockResolvedValue({ user: { email: 'a@test.com' } });
+    findUniqueMock.mockResolvedValue({ isAdmin: true });
+    const { GET } = await import('../src/app/api/admin/gemini/route');
+    const res = await GET(new Request('http://test') as any);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ systemPrompt: 'prompt' });
+    expect(geminiServiceMock.getSystemPrompt).toHaveBeenCalled();
+  });
+});

--- a/tests/analyze.test.ts
+++ b/tests/analyze.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+let retrieveFileMock: any;
+let sendMessageMock: any;
+
+vi.mock('@google/generative-ai/server', () => ({
+  GoogleAIFileManager: vi.fn().mockImplementation(() => ({
+    retrieveFile: (...args: any[]) => retrieveFileMock(...args)
+  }))
+}));
+
+vi.mock('@google/generative-ai', () => ({
+  GoogleGenerativeAI: vi.fn().mockImplementation(() => ({
+    getGenerativeModel: vi.fn().mockReturnValue({
+      startChat: vi.fn().mockReturnValue({
+        sendMessage: (...args: any[]) => sendMessageMock(...args)
+      })
+    })
+  }))
+}));
+
+describe('POST /api/analyze', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    retrieveFileMock = vi.fn();
+    sendMessageMock = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns analysis on success', async () => {
+    process.env.GEMINI_API_KEY = 'key';
+    retrieveFileMock.mockResolvedValue({ data: Buffer.from('123'), mimeType: 'text/plain' });
+    sendMessageMock.mockResolvedValue({ response: { text: () => 'analysis data' } });
+
+    const { POST } = await import('../src/app/api/analyze/route');
+
+    const req = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ fileId: 'file123' })
+    });
+
+    const res = await POST(req as any);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.analysis).toBe('analysis data');
+  });
+
+  it('returns 400 when fileId missing', async () => {
+    process.env.GEMINI_API_KEY = 'key';
+    const { POST } = await import('../src/app/api/analyze/route');
+    const res = await POST(new Request('http://test', { method: 'POST', body: JSON.stringify({}) }) as any);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ success: false, error: 'No fileId provided' });
+  });
+
+  it('returns 500 when API key missing', async () => {
+    delete process.env.GEMINI_API_KEY;
+    const { POST } = await import('../src/app/api/analyze/route');
+    const req = new Request('http://test', { method: 'POST', body: JSON.stringify({ fileId: 'x' }) });
+    const res = await POST(req as any);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+  });
+});

--- a/tests/upload-temp.test.ts
+++ b/tests/upload-temp.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+
+let uploadFileMock: any;
+
+vi.mock('@google/generative-ai/server', () => ({
+  GoogleAIFileManager: vi.fn().mockImplementation(() => ({
+    uploadFile: (...args: any[]) => uploadFileMock(...args)
+  }))
+}));
+
+describe('POST /api/upload-temp', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    uploadFileMock = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uploads file and returns fileId', async () => {
+    process.env.GEMINI_API_KEY = 'key';
+    const writeSpy = vi.spyOn(fs, 'writeFile').mockResolvedValue();
+    const unlinkSpy = vi.spyOn(fs, 'unlink').mockResolvedValue();
+    const fileId = 'files/123';
+    uploadFileMock.mockResolvedValue({ file: { name: fileId } });
+
+    const { POST } = await import('../src/app/api/upload-temp/route');
+
+    const formData = new FormData();
+    formData.append('file', new File(['content'], 'test.txt', { type: 'text/plain' }));
+    const req = new Request('http://test', { method: 'POST', body: formData });
+
+    const res = await POST(req);
+    const json = await res.json();
+    expect(json).toEqual({ success: true, fileId });
+    expect(writeSpy).toHaveBeenCalled();
+    expect(unlinkSpy).toHaveBeenCalled();
+  });
+
+  it('returns 400 when no file provided', async () => {
+    process.env.GEMINI_API_KEY = 'key';
+    const { POST } = await import('../src/app/api/upload-temp/route');
+    const formData = new FormData();
+    const req = new Request('http://test', { method: 'POST', body: formData });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ success: false, error: 'No file uploaded.' });
+  });
+
+  it('returns 500 if API key missing', async () => {
+    delete process.env.GEMINI_API_KEY;
+    const { POST } = await import('../src/app/api/upload-temp/route');
+
+    const formData = new FormData();
+    formData.append('file', new File(['data'], 'a.txt', { type: 'text/plain' }));
+    const req = new Request('http://test', { method: 'POST', body: formData });
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `/api/upload-temp` successful path and failure cases
- add tests for `/api/analyze` covering success and error scenarios
- test admin authentication for `/api/admin/gemini`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_683fa59473a4832db3262a05984f4099