### PR TITLE
Refactor analyze API to use GeminiService prompt

### DIFF
--- a/tests/analyze.test.ts
+++ b/tests/analyze.test.ts
@@ -2,11 +2,32 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 let retrieveFileMock: any;
 let sendMessageMock: any;
+let getServerSessionMock: any;
+let findUniqueMock: any;
+let geminiConfigMock: any;
+let apiUsageCreateMock: any;
+let getGeminiServiceMock: any;
 
 vi.mock('@google/generative-ai/server', () => ({
   GoogleAIFileManager: vi.fn().mockImplementation(() => ({
     retrieveFile: (...args: any[]) => retrieveFileMock(...args)
   }))
+}));
+
+vi.mock('next-auth/next', () => ({
+  getServerSession: (...args: any[]) => getServerSessionMock(...args)
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: { findUnique: (...args: any[]) => findUniqueMock(...args) },
+    geminiConfig: { findFirst: (...args: any[]) => geminiConfigMock(...args) },
+    apiUsage: { create: (...args: any[]) => apiUsageCreateMock(...args) },
+  }
+}));
+
+vi.mock('@/lib/gemini-service', () => ({
+  getGeminiService: () => getGeminiServiceMock,
 }));
 
 vi.mock('@google/generative-ai', () => ({
@@ -24,6 +45,11 @@ describe('POST /api/analyze', () => {
     vi.resetModules();
     retrieveFileMock = vi.fn();
     sendMessageMock = vi.fn();
+    getServerSessionMock = vi.fn().mockResolvedValue(null);
+    findUniqueMock = vi.fn();
+    geminiConfigMock = vi.fn();
+    apiUsageCreateMock = vi.fn();
+    getGeminiServiceMock = { getSystemPrompt: vi.fn().mockReturnValue('prompt') };
   });
 
   afterEach(() => {
@@ -32,6 +58,9 @@ describe('POST /api/analyze', () => {
 
   it('returns analysis on success', async () => {
     process.env.GEMINI_API_KEY = 'key';
+    findUniqueMock.mockResolvedValue(null);
+    geminiConfigMock.mockResolvedValue(null);
+    apiUsageCreateMock.mockResolvedValue({});
     retrieveFileMock.mockResolvedValue({ data: Buffer.from('123'), mimeType: 'text/plain' });
     sendMessageMock.mockResolvedValue({ response: { text: () => 'analysis data' } });
 
@@ -50,6 +79,8 @@ describe('POST /api/analyze', () => {
 
   it('returns 400 when fileId missing', async () => {
     process.env.GEMINI_API_KEY = 'key';
+    geminiConfigMock.mockResolvedValue(null);
+    apiUsageCreateMock.mockResolvedValue({});
     const { POST } = await import('../src/app/api/analyze/route');
     const res = await POST(new Request('http://test', { method: 'POST', body: JSON.stringify({}) }) as any);
     expect(res.status).toBe(400);
@@ -58,6 +89,8 @@ describe('POST /api/analyze', () => {
 
   it('returns 500 when API key missing', async () => {
     delete process.env.GEMINI_API_KEY;
+    geminiConfigMock.mockResolvedValue(null);
+    apiUsageCreateMock.mockResolvedValue({});
     const { POST } = await import('../src/app/api/analyze/route');
     const req = new Request('http://test', { method: 'POST', body: JSON.stringify({ fileId: 'x' }) });
     const res = await POST(req as any);


### PR DESCRIPTION
## Summary
- use `getGeminiService()` to obtain system prompt in analyze API
- update analyze tests to mock prisma, auth and service
- adjust admin Gemini tests to mock extra prisma calls and expect full response

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fa937c688832da93d8aeff9660974