### PR TITLE
Validate MAX_UPLOAD_BYTES env var

### DIFF
--- a/src/app/api/upload-temp/route.ts
+++ b/src/app/api/upload-temp/route.ts
@@ -10,10 +10,16 @@ const apiKey = process.env.GEMINI_API_KEY;
 
 // Determine the maximum allowed upload size (defaults to 5MB)
 const DEFAULT_MAX_UPLOAD_BYTES = 5 * 1024 * 1024; // 5 MB
-const parsedUploadBytes = parseInt(process.env.MAX_UPLOAD_BYTES ?? '');
-export const MAX_UPLOAD_BYTES = Number.isNaN(parsedUploadBytes)
-  ? DEFAULT_MAX_UPLOAD_BYTES
-  : parsedUploadBytes;
+const rawUploadBytes = process.env.MAX_UPLOAD_BYTES;
+const trimmedUploadBytes = rawUploadBytes?.trim() ?? '';
+const parsedUploadBytes = parseInt(trimmedUploadBytes, 10);
+
+// Validate that the env var is a pure numeric string; otherwise fall back
+// to the default.
+export const MAX_UPLOAD_BYTES =
+  /^\d+$/.test(trimmedUploadBytes) && !Number.isNaN(parsedUploadBytes)
+    ? parsedUploadBytes
+    : DEFAULT_MAX_UPLOAD_BYTES;
 
 // Initialize the File Manager (only if API key exists)
 const fileManager = apiKey ? new GoogleAIFileManager(apiKey) : null;

--- a/tests/upload-temp.test.ts
+++ b/tests/upload-temp.test.ts
@@ -81,4 +81,23 @@ describe('POST /api/upload-temp', () => {
     expect(writeSpy).not.toHaveBeenCalled();
     expect(unlinkSpy).not.toHaveBeenCalled();
   });
+
+  it('uses default limit when MAX_UPLOAD_BYTES has letters', async () => {
+    process.env.GEMINI_API_KEY = 'key';
+    process.env.MAX_UPLOAD_BYTES = '5mb';
+    const writeSpy = vi.spyOn(fs, 'writeFile').mockResolvedValue();
+    const unlinkSpy = vi.spyOn(fs, 'unlink').mockResolvedValue();
+
+    const { POST, MAX_UPLOAD_BYTES } = await import('../src/app/api/upload-temp/route');
+
+    const big = new Uint8Array(MAX_UPLOAD_BYTES + 1);
+    const formData = new FormData();
+    formData.append('file', new File([big], 'big.dat', { type: 'application/octet-stream' }));
+    const req = new Request('http://test', { method: 'POST', body: formData });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect(writeSpy).not.toHaveBeenCalled();
+    expect(unlinkSpy).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- tighten MAX_UPLOAD_BYTES parsing logic
- test using letters in the env var to ensure default limit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fae1eee54832d9398df11d77b330f