### PR TITLE
Refactor pages to use shared layout

### DIFF
--- a/src/app/admin/feedback/page.tsx
+++ b/src/app/admin/feedback/page.tsx
@@ -3,6 +3,7 @@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import AdminRoute from "@/components/admin-route";
 import { Button } from "@/components/ui/button";
+import Layout from "@/components/layout";
 import Link from "next/link";
 import { useState } from "react";
 
@@ -65,29 +66,25 @@ export default function FeedbackPage() {
 
   return (
     <AdminRoute>
-      <div className="flex min-h-screen flex-col bg-background">
-        <header className="sticky top-0 z-10 w-full border-b border-border bg-background/95 backdrop-blur">
-          <div className="container flex h-16 items-center justify-between">
-            <div className="flex items-center gap-2">
-              <Link href="/admin" className="text-xl font-bold text-primary">
-                BloodInsight AI
-              </Link>
-              <span className="px-2 py-1 rounded text-xs bg-secondary text-secondary-foreground">
-                Admin Console
-              </span>
-            </div>
-            <nav className="flex items-center gap-4">
-              <Button variant="ghost" asChild>
-                <Link href="/admin">Dashboard</Link>
-              </Button>
-              <Button variant="ghost" asChild>
-                <Link href="/dashboard">Back to App</Link>
-              </Button>
-            </nav>
-          </div>
-        </header>
-
-        <main className="flex-1 container py-8">
+      <Layout
+        homeHref="/admin"
+        headerLeftExtra={
+          <span className="px-2 py-1 rounded text-xs bg-secondary text-secondary-foreground">
+            Admin Console
+          </span>
+        }
+        headerRight={
+          <>
+            <Button variant="ghost" asChild>
+              <Link href="/admin">Dashboard</Link>
+            </Button>
+            <Button variant="ghost" asChild>
+              <Link href="/dashboard">Back to App</Link>
+            </Button>
+          </>
+        }
+      >
+        <div className="container py-8">
           <div className="flex items-center justify-between mb-8">
             <h1 className="text-3xl font-bold">Feedback Management</h1>
           </div>
@@ -160,14 +157,8 @@ export default function FeedbackPage() {
           </Tabs>
         </main>
 
-        <footer className="border-t border-border py-6 bg-background">
-          <div className="container flex flex-col md:flex-row items-center justify-between gap-4">
-            <p className="text-sm text-muted-foreground">
-              © 2025 BloodInsight AI. Admin Console.
-            </p>
-          </div>
-        </footer>
-      </div>
+        </div>
+      </Layout>
     </AdminRoute>
   );
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -2,6 +2,7 @@
 
 import AdminRoute from "@/components/admin-route";
 import { Button } from "@/components/ui/button";
+import Layout from "@/components/layout";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import Link from "next/link";
 import { useEffect, useState } from "react";
@@ -95,26 +96,20 @@ export default function AdminPage() {
 
   return (
     <AdminRoute>
-      <div className="flex min-h-screen flex-col bg-background">
-        <header className="sticky top-0 z-10 w-full border-b border-border bg-background/95 backdrop-blur">
-          <div className="container flex h-16 items-center justify-between">
-            <div className="flex items-center gap-2">
-              <Link href="/dashboard" className="text-xl font-bold text-primary">
-                BloodInsight AI
-              </Link>
-              <span className="px-2 py-1 rounded text-xs bg-secondary text-secondary-foreground">
-                Admin Console
-              </span>
-            </div>
-            <nav className="flex items-center gap-4">
-              <Button variant="ghost" asChild>
-                <Link href="/dashboard">Back to App</Link>
-              </Button>
-            </nav>
-          </div>
-        </header>
-
-        <main className="flex-1 container py-8">
+      <Layout
+        homeHref="/dashboard"
+        headerLeftExtra={
+          <span className="px-2 py-1 rounded text-xs bg-secondary text-secondary-foreground">
+            Admin Console
+          </span>
+        }
+        headerRight={
+          <Button variant="ghost" asChild>
+            <Link href="/dashboard">Back to App</Link>
+          </Button>
+        }
+      >
+        <div className="container py-8">
           <div className="flex items-center justify-between mb-8">
             <h1 className="text-3xl font-bold">Admin Console</h1>
           </div>
@@ -394,16 +389,8 @@ export default function AdminPage() {
               </div>
             </TabsContent>
           </Tabs>
-        </main>
-
-        <footer className="border-t border-border py-6 bg-background">
-          <div className="container flex flex-col md:flex-row items-center justify-between gap-4">
-            <p className="text-sm text-muted-foreground">
-              © 2025 BloodInsight AI. Admin Console.
-            </p>
-          </div>
-        </footer>
-      </div>
+        </div>
+      </Layout>
     </AdminRoute>
   );
 }

--- a/src/app/analysis/page.tsx
+++ b/src/app/analysis/page.tsx
@@ -2,6 +2,7 @@
 
 import ProtectedRoute from "@/components/protected-route";
 import { Button } from "@/components/ui/button";
+import Layout from "@/components/layout";
 import Link from "next/link";
 import { useSearchParams } from 'next/navigation'; // Import useSearchParams
 import { useEffect, useState } from "react";
@@ -81,23 +82,15 @@ export default function AnalysisPage() {
 
   return (
     <ProtectedRoute>
-      <div className="flex min-h-screen flex-col bg-background">
-        <header className="sticky top-0 z-10 w-full border-b border-border bg-background/95 backdrop-blur">
-          <div className="container flex h-16 items-center justify-between">
-            <div className="flex items-center gap-2">
-              <Link href="/dashboard" className="text-xl font-bold text-primary">
-                BloodInsight AI
-              </Link>
-            </div>
-            <nav className="flex items-center gap-4">
-              <Button variant="ghost" asChild>
-                <Link href="/dashboard">Dashboard</Link>
-              </Button>
-            </nav>
-          </div>
-        </header>
-
-        <main className="flex-1 container py-8">
+      <Layout
+        homeHref="/dashboard"
+        headerRight={
+          <Button variant="ghost" asChild>
+            <Link href="/dashboard">Dashboard</Link>
+          </Button>
+        }
+      >
+        <div className="container py-8">
           <div className="flex items-center justify-between mb-8">
             <h1 className="text-3xl font-bold">Analysis Results</h1>
           </div>
@@ -160,19 +153,8 @@ export default function AnalysisPage() {
               </div>
             </div>
           )}
-        </main>
-
-        <footer className="border-t border-border py-6 bg-background">
-          <div className="container flex flex-col md:flex-row items-center justify-between gap-4">
-            <p className="text-sm text-muted-foreground">
-              © 2025 BloodInsight AI. For educational purposes only.
-            </p>
-            <p className="text-sm text-muted-foreground">
-              Not intended to replace medical advice.
-            </p> 
-          </div>
-        </footer>
-      </div>
+        </div>
+      </Layout>
     </ProtectedRoute>
   );
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import ProtectedRoute from "@/components/protected-route";
 import { Button } from "@/components/ui/button";
+import Layout from "@/components/layout";
 import { signOut, useSession } from "next-auth/react";
 import Link from "next/link";
 
@@ -10,21 +11,15 @@ export default function DashboardPage() {
 
   return (
     <ProtectedRoute>
-      <div className="flex min-h-screen flex-col bg-background">
-        <header className="sticky top-0 z-10 w-full border-b border-border bg-background/95 backdrop-blur">
-          <div className="container flex h-16 items-center justify-between">
-            <div className="flex items-center gap-2">
-              <span className="text-xl font-bold text-primary">BloodInsight AI</span>
-            </div>
-            <nav className="flex items-center gap-4">
-              <Button variant="ghost" onClick={() => signOut({ callbackUrl: "/" })}>
-                Sign Out
-              </Button>
-            </nav>
-          </div>
-        </header>
-
-        <main className="flex-1 container py-8">
+      <Layout
+        homeHref="/dashboard"
+        headerRight={
+          <Button variant="ghost" onClick={() => signOut({ callbackUrl: "/" })}>
+            Sign Out
+          </Button>
+        }
+      >
+        <div className="container py-8">
           <div className="flex items-center justify-between mb-8">
             <h1 className="text-3xl font-bold">Dashboard</h1>
             <div className="flex items-center gap-2">
@@ -65,19 +60,8 @@ export default function DashboardPage() {
               </Button>
             </div>
           </div>
-        </main>
-
-        <footer className="border-t border-border py-6 bg-background">
-          <div className="container flex flex-col md:flex-row items-center justify-between gap-4">
-            <p className="text-sm text-muted-foreground">
-              © 2025 BloodInsight AI. For educational purposes only.
-            </p>
-            <p className="text-sm text-muted-foreground">
-              Not intended to replace medical advice.
-            </p>
-          </div>
-        </footer>
-      </div>
+        </div>
+      </Layout>
     </ProtectedRoute>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,24 +2,17 @@
 
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
+import Layout from "@/components/layout";
 
 export default function Home() {
   return (
-    <div className="flex flex-col min-h-screen bg-background">
-      <header className="sticky top-0 z-10 w-full border-b border-border bg-background/95 backdrop-blur">
-        <div className="container flex h-16 items-center justify-between">
-          <div className="flex items-center gap-2">
-            <span className="text-xl font-bold text-primary">BloodInsight AI</span>
-          </div>
-          <nav className="flex items-center gap-4">
-            <Button variant="ghost" asChild>
-              <Link href="/login">Sign In</Link>
-            </Button>
-          </nav>
-        </div>
-      </header>
-      
-      <main className="flex-1">
+    <Layout
+      headerRight={
+        <Button variant="ghost" asChild>
+          <Link href="/login">Sign In</Link>
+        </Button>
+      }
+    >
         <section className="py-20">
           <div className="container flex flex-col items-center text-center">
             <h1 className="text-4xl font-bold tracking-tight sm:text-5xl md:text-6xl">
@@ -95,18 +88,6 @@ export default function Home() {
             </Button>
           </div>
         </section>
-      </main>
-      
-      <footer className="border-t border-border py-6 bg-background">
-        <div className="container flex flex-col md:flex-row items-center justify-between gap-4">
-          <p className="text-sm text-muted-foreground">
-            © 2025 BloodInsight AI. For educational purposes only.
-          </p>
-          <p className="text-sm text-muted-foreground">
-            Not intended to replace medical advice.
-          </p>
-        </div>
-      </footer>
-    </div>
+    </Layout>
   );
 }

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -2,6 +2,7 @@
 
 import ProtectedRoute from "@/components/protected-route";
 import { Button } from "@/components/ui/button";
+import Layout from "@/components/layout";
 import { useCallback, useState } from "react";
 import { useDropzone } from "react-dropzone"; 
 import type { FileWithPath } from "react-dropzone"; 
@@ -84,21 +85,15 @@ export default function UploadPage() {
 
   return (
     <ProtectedRoute>
-      <div className="flex min-h-screen flex-col bg-background">
-        <header className="sticky top-0 z-10 w-full border-b border-border bg-background/95 backdrop-blur">
-          <div className="container flex h-16 items-center justify-between">
-            <div className="flex items-center gap-2">
-              <Link href="/dashboard" className="text-xl font-bold text-primary">BloodInsight AI</Link>
-            </div>
-            <nav className="flex items-center gap-4">
-              <Button variant="ghost" asChild>
-                <Link href="/dashboard">Dashboard</Link>
-              </Button>
-            </nav>
-          </div>
-        </header>
-
-        <main className="flex-1 container py-8">
+      <Layout
+        homeHref="/dashboard"
+        headerRight={
+          <Button variant="ghost" asChild>
+            <Link href="/dashboard">Dashboard</Link>
+          </Button>
+        }
+      >
+        <div className="container py-8">
           <div className="flex items-center justify-between mb-8">
             <h1 className="text-3xl font-bold">Upload Lab Reports</h1>
           </div>
@@ -279,19 +274,8 @@ export default function UploadPage() {
               </ul>
             </div>
           </div>
-        </main>
-
-        <footer className="border-t border-border py-6 bg-background">
-          <div className="container flex flex-col md:flex-row items-center justify-between gap-4">
-            <p className="text-sm text-muted-foreground">
-              © 2025 BloodInsight AI. For educational purposes only.
-            </p>
-            <p className="text-sm text-muted-foreground">
-              Not intended to replace medical advice.
-            </p>
-          </div>
-        </footer>
-      </div>
+        </div>
+      </Layout>
     </ProtectedRoute>
   );
 }

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import Link from "next/link";
+import { ReactNode } from "react";
+
+interface LayoutProps {
+  children: ReactNode;
+  headerRight?: ReactNode;
+  headerLeftExtra?: ReactNode;
+  homeHref?: string;
+}
+
+export default function Layout({
+  children,
+  headerRight,
+  headerLeftExtra,
+  homeHref = "/",
+}: LayoutProps) {
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <header className="sticky top-0 z-10 w-full border-b border-border bg-background/95 backdrop-blur">
+        <div className="container flex h-16 items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Link href={homeHref} className="text-xl font-bold text-primary">
+              BloodInsight AI
+            </Link>
+            {headerLeftExtra}
+          </div>
+          <nav className="flex items-center gap-4">{headerRight}</nav>
+        </div>
+      </header>
+      <main className="flex-1">{children}</main>
+      <footer className="border-t border-border py-6 bg-background">
+        <div className="container flex flex-col md:flex-row items-center justify-between gap-4">
+          <p className="text-sm text-muted-foreground">
+            © 2025 BloodInsight AI. For educational purposes only.
+          </p>
+          <p className="text-sm text-muted-foreground">
+            Not intended to replace medical advice.
+          </p>
+        </div>
+      </footer>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a new Layout component with common header and footer
- wrap various pages with the new layout

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb4e92f08832d8922f138764f08e8