### PR TITLE
Reduce output tokens to supported limit

### DIFF
--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -45,7 +45,7 @@ export async function POST(req: NextRequest) {
       temperature: 1,
       topP: 0.95,
       topK: 64,
-      maxOutputTokens: 65536,
+      maxOutputTokens: 8192,
     };
 
     const chatSession = model.startChat({ generationConfig, history: [] });


### PR DESCRIPTION
## Summary
- lower `maxOutputTokens` in `src/app/api/analyze/route.ts` to 8192
- verify that API tests still return complete analyses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fbc739358832d8b8897a95fd288c5