### PR TITLE
Add feedback management API

### DIFF
--- a/src/app/admin/feedback/page.tsx
+++ b/src/app/admin/feedback/page.tsx
@@ -5,54 +5,27 @@ import AdminRoute from "@/components/admin-route";
 import { Button } from "@/components/ui/button";
 import Layout from "@/components/layout";
 import Link from "next/link";
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { fetchFeedback, FeedbackItem } from "@/lib/feedback";
 
 export default function FeedbackPage() {
   const [activeTab, setActiveTab] = useState("all");
 
-  // Sample feedback data
-  const feedbackItems = [
-    {
-      id: 1,
-      user: "user123@example.com",
-      date: "2025-04-01",
-      category: "Analysis",
-      status: "New",
-      message: "The analysis was very helpful, but I wish it would explain more about what my cholesterol levels mean for my overall health."
-    },
-    {
-      id: 2,
-      user: "user456@example.com",
-      date: "2025-03-30",
-      category: "UI/UX",
-      status: "In Progress",
-      message: "The dark theme is great, but the text is sometimes hard to read on mobile devices."
-    },
-    {
-      id: 3,
-      user: "user789@example.com",
-      date: "2025-03-28",
-      category: "Feature Request",
-      status: "Completed",
-      message: "It would be helpful to have a way to compare multiple reports side by side."
-    },
-    {
-      id: 4,
-      user: "user321@example.com",
-      date: "2025-03-25",
-      category: "Bug",
-      status: "New",
-      message: "When I try to upload a PDF with multiple pages, only the first page gets analyzed."
-    },
-    {
-      id: 5,
-      user: "user654@example.com",
-      date: "2025-03-22",
-      category: "Analysis",
-      status: "Completed",
-      message: "The vitamin D recommendations were very specific and helpful. Thank you!"
-    }
-  ];
+  const [feedbackItems, setFeedbackItems] = useState<FeedbackItem[]>([]);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchFeedback();
+        setFeedbackItems(data);
+      } catch (err) {
+        console.error("Failed to load feedback", err);
+        setLoadError("Failed to load feedback");
+      }
+    };
+    load();
+  }, []);
 
   const filteredFeedback = activeTab === "all" 
     ? feedbackItems 
@@ -88,6 +61,11 @@ export default function FeedbackPage() {
           <div className="flex items-center justify-between mb-8">
             <h1 className="text-3xl font-bold">Feedback Management</h1>
           </div>
+          {loadError && (
+            <div className="mb-6 p-3 bg-destructive/10 border border-destructive/30 rounded text-destructive text-sm">
+              {loadError}
+            </div>
+          )}
 
           <Tabs defaultValue="all" className="w-full" onValueChange={setActiveTab}>
             <TabsList className="grid grid-cols-4 mb-8">
@@ -155,7 +133,6 @@ export default function FeedbackPage() {
               </div>
             </TabsContent>
           </Tabs>
-        </main>
 
         </div>
       </Layout>

--- a/src/app/api/admin/feedback/route.ts
+++ b/src/app/api/admin/feedback/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { prisma } from '@/lib/prisma';
+
+// Verify the request is from an authenticated admin user
+async function verifyAdmin() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const user = await prisma.user.findUnique({
+    where: { email: session.user?.email ?? '' },
+    select: { id: true, isAdmin: true },
+  });
+  if (!user?.isAdmin) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+  return { id: user.id };
+}
+
+export async function GET() {
+  const admin = await verifyAdmin();
+  if ('status' in admin) return admin as any;
+
+  const feedback = await prisma.feedback.findMany({
+    orderBy: { createdAt: 'desc' },
+    include: { user: { select: { email: true } } },
+  });
+
+  const formatted = feedback.map(f => ({
+    id: f.id,
+    user: f.user.email,
+    date: f.createdAt.toISOString(),
+    category: f.category,
+    status: f.status,
+    message: f.message,
+  }));
+
+  return NextResponse.json(formatted);
+}
+
+export async function POST(req: NextRequest) {
+  const admin = await verifyAdmin();
+  if ('status' in admin) return admin as any;
+
+  const { userId, message, category, status } = await req.json();
+  if (!userId || !message || !category) {
+    return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
+  }
+
+  const item = await prisma.feedback.create({
+    data: {
+      userId,
+      message,
+      category,
+      status: status || 'New',
+    },
+  });
+
+  return NextResponse.json(item);
+}
+
+export async function PUT(req: NextRequest) {
+  const admin = await verifyAdmin();
+  if ('status' in admin) return admin as any;
+
+  const { id, ...data } = await req.json();
+  if (!id) {
+    return NextResponse.json({ error: 'Missing id' }, { status: 400 });
+  }
+
+  const item = await prisma.feedback.update({ where: { id }, data });
+  return NextResponse.json(item);
+}
+
+export async function DELETE(req: NextRequest) {
+  const admin = await verifyAdmin();
+  if ('status' in admin) return admin as any;
+
+  const { id } = await req.json();
+  if (!id) {
+    return NextResponse.json({ error: 'Missing id' }, { status: 400 });
+  }
+  await prisma.feedback.delete({ where: { id } });
+  return NextResponse.json({ success: true });
+}

--- a/src/lib/feedback.ts
+++ b/src/lib/feedback.ts
@@ -1,0 +1,64 @@
+import { prisma } from './prisma';
+
+export interface FeedbackRecord {
+  id: string;
+  userId: string;
+  message: string;
+  category: string;
+  status: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export async function createFeedback(userId: string, message: string, category: string, status = 'New'): Promise<FeedbackRecord> {
+  return prisma.feedback.create({
+    data: { userId, message, category, status },
+  });
+}
+
+export async function updateFeedback(id: string, data: Partial<{ message: string; category: string; status: string }>): Promise<FeedbackRecord> {
+  return prisma.feedback.update({ where: { id }, data });
+}
+
+export interface FeedbackItem {
+  id: string;
+  user: string;
+  date: string;
+  category: string;
+  status: string;
+  message: string;
+}
+
+export async function fetchFeedback(): Promise<FeedbackItem[]> {
+  const res = await fetch('/api/admin/feedback');
+  if (!res.ok) throw new Error('Failed to fetch feedback');
+  return res.json();
+}
+
+export async function sendFeedback(data: { userId: string; message: string; category: string; }): Promise<FeedbackItem> {
+  const res = await fetch('/api/admin/feedback', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to submit feedback');
+  return res.json();
+}
+
+export async function updateFeedbackItem(id: string, data: { status?: string; message?: string; category?: string; }): Promise<FeedbackItem> {
+  const res = await fetch('/api/admin/feedback', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id, ...data }),
+  });
+  if (!res.ok) throw new Error('Failed to update feedback');
+  return res.json();
+}
+
+export async function deleteFeedback(id: string): Promise<void> {
+  await fetch('/api/admin/feedback', {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id }),
+  });
+}


### PR DESCRIPTION
## Summary
- add CRUD API for admin feedback management
- implement Prisma helper for feedback
- load feedback from API in the admin page

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fc300fe28832d9449575649765385